### PR TITLE
Use new-computed polyfill to support computeds in Ember v2.0.0-beta.2+

### DIFF
--- a/addon/components/credit-card-form.js
+++ b/addon/components/credit-card-form.js
@@ -1,8 +1,9 @@
+import computed from 'ember-new-computed';
 import Ember from 'ember';
 import Validations from 'ember-credit-cards/utils/validations';
 import Cards from 'ember-credit-cards/utils/cards';
 
-const {Component, computed, observer} = Ember;
+const {Component, observer} = Ember;
 
 export default Component.extend({
   tagName: 'form',

--- a/addon/components/input-credit-card-cvc.js
+++ b/addon/components/input-credit-card-cvc.js
@@ -1,8 +1,9 @@
+import computed from 'ember-new-computed';
 import Ember from 'ember';
 import hasTextSelected from 'ember-credit-cards/utils/has-text-selected';
 import isDigitKeypress from 'ember-credit-cards/utils/is-digit-keypress';
 
-const {TextField, computed} = Ember;
+const {TextField} = Ember;
 
 export default TextField.extend({
   classNames: ['input-credit-card-cvc'],
@@ -28,15 +29,16 @@ export default TextField.extend({
   },
 
 
-  value: computed('cvc', function(key, value) {
-    var number = this.get('cvc');
+  value: computed('cvc', {
+    get() {
+      var number = this.get('cvc');
+      return number;
+    },
 
-    if (arguments.length > 1) {
-      number = value.replace(/\D/g, '').slice(0, 4);
+    set(key, value) {
+      var number = value.replace(/\D/g, '').slice(0, 4);
       this.set('cvc', value);
+      return number;
     }
-
-    return number;
   })
-
 });

--- a/addon/components/input-credit-card-expiration.js
+++ b/addon/components/input-credit-card-expiration.js
@@ -1,9 +1,10 @@
+import computed from 'ember-new-computed';
 import Ember from 'ember';
 import formatters from 'ember-credit-cards/utils/formatters';
 import hasTextSelected from 'ember-credit-cards/utils/has-text-selected';
 import isDigitKeypress from 'ember-credit-cards/utils/is-digit-keypress';
 
-const {TextField, computed} = Ember;
+const {TextField} = Ember;
 
 function inputValid(value) {
   if (!value) {
@@ -62,23 +63,25 @@ export default TextField.extend({
     return inputValid(value);
   },
 
+  value: computed('month', 'year', {
+    get() {
+      var month = this.get('month');
+      var year  = this.get('year');
 
-  value: computed('month', 'year', function(key, value) {
-    var month = this.get('month');
-    var year  = this.get('year');
+      return formatters.formatExpiration(month, year);
+    },
 
-    if (arguments.length > 1) {
+    set(key, value) {
       var parsed = parseInput(value);
-
-      month = parsed[0];
-      year = parsed[1];
+      var month = parsed[0];
+      var year = parsed[1];
 
       this.setProperties({
         month: month,
         year: year
       });
-    } 
 
-    return formatters.formatExpiration(month, year);
+      return formatters.formatExpiration(month, year);
+    }
   })
 });

--- a/addon/components/input-credit-card-number.js
+++ b/addon/components/input-credit-card-number.js
@@ -1,3 +1,4 @@
+import computed from 'ember-new-computed';
 import Ember from 'ember';
 import hasTextSelected from 'ember-credit-cards/utils/has-text-selected';
 import formatters from 'ember-credit-cards/utils/formatters';
@@ -5,7 +6,7 @@ import cards from 'ember-credit-cards/utils/cards';
 import isDigitKeypress from 'ember-credit-cards/utils/is-digit-keypress';
 
 const cardFromNumber = cards.fromNumber;
-const {TextField, computed} = Ember;
+const {TextField} = Ember;
 
 function inputValid(value) {
   value = (value + '').replace(/\D/g, '');
@@ -42,15 +43,17 @@ export default TextField.extend({
   },
 
 
-  value: computed('number', function(key, value) {
-    var number = this.get('number');
+  value: computed('number', {
+    get() {
+      var number = this.get('number');
+      return formatters.formatNumber(number);
+    },
 
-    if (arguments.length > 1) {
-      number = value;
+    set(key, value) {
+      var number = value;
       this.set('number', value);
+
+      return formatters.formatNumber(number);
     }
-
-    return formatters.formatNumber(number);
   })
-
 });

--- a/addon/components/input-credit-card-zipcode.js
+++ b/addon/components/input-credit-card-zipcode.js
@@ -1,9 +1,10 @@
+import computed from 'ember-new-computed';
 import Ember from 'ember';
 import hasTextSelected from 'ember-credit-cards/utils/has-text-selected';
 import formatters from 'ember-credit-cards/utils/formatters';
 import isDigitKeypress from 'ember-credit-cards/utils/is-digit-keypress';
 
-const {TextField, computed} = Ember;
+const {TextField} = Ember;
 
 export default TextField.extend({
   type: 'tel',
@@ -25,15 +26,16 @@ export default TextField.extend({
     return value.length <= 10;
   },
 
-  value: computed('zipcode', function(key, value) {
-    var zipcode = this.get('zipcode');
+  value: computed('zipcode', {
+    get() {
+      var zipcode = this.get('zipcode');
+      return formatters.formatZipcode(zipcode);
+    },
 
-    if (arguments.length > 1) {
-      zipcode = value;
+    set(key, value) {
+      var zipcode = value;
       this.set('zipcode', value);
+      return formatters.formatZipcode(zipcode);
     }
-
-    return formatters.formatZipcode(zipcode);
   })
-
 });

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "ember-addon"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.0.0"
+    "ember-cli-babel": "^5.0.0",
+    "ember-new-computed": "1.0.2"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",


### PR DESCRIPTION
Thanks for a great addon!

This will allow the computeds in the components to work in Ember v2.0.0-beta.2. The new-computed addon allows usage of the new Ember Computed syntax as described in emberjs/rfcs#11 in older versions of Ember (from the [README](https://github.com/rwjblue/ember-new-computed)).

*`credit-card-form` uses bind-attr which was also removed in Ember v2.0.0-beta.2*