### PR TITLE
Bumping versions in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   ],
   "dependencies": {
     "ember-cli-babel": "^5.1.6",
-    "ember-runtime-enumerable-includes-polyfill": "1.0.2"
+    "ember-runtime-enumerable-includes-polyfill": "2.0.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-credit-cards",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A credit card utility library and form elements.",
   "directories": {
     "doc": "doc",


### PR DESCRIPTION
This PR addresses 2 minor issues. [#15](https://github.com/arenoir/ember-credit-cards/issues/15) and [#16](https://github.com/arenoir/ember-credit-cards/issues/16).

- version in package.json does not match latest release version
- ember-runtime-enumerable-includes-polyfill can be bumped to latest version

While using dependency-lint in our project - `ember-runtime-enumerable-includes-polyfill` was behind other dependencies, including ember-data. And the issue with package.json threw me for a small loop while using `npm link`. 