### PR TITLE
Updating ember-runtime-enumerable-includes-polyfill to include caret

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   ],
   "dependencies": {
     "ember-cli-babel": "^6.8.2",
-    "ember-runtime-enumerable-includes-polyfill": "2.0.0"
+    "ember-runtime-enumerable-includes-polyfill": "^2.0.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",


### PR DESCRIPTION
whoops... should have included that caret in the last PR. 