### PR TITLE
only allow 4 digit cvv code for amex

### DIFF
--- a/addon/utils/cards.js
+++ b/addon/utils/cards.js
@@ -48,7 +48,7 @@ var cards = [
     pattern: /^3[47]/,
     format: /(\d{1,4})(\d{1,6})?(\d{1,5})?/,
     length: [15],
-    cvcLength: [3,4],
+    cvcLength: [4],
     luhn: true
   },{
     type: 'dinersclub',

--- a/tests/unit/utils/validations-test.js
+++ b/tests/unit/utils/validations-test.js
@@ -20,7 +20,7 @@ test('Validating a card number', function(assert) {
 
 test('validateCVC without card type', function(assert) {
   var validate = validations.validateCVC;
-  
+
   assert.equal( validate(''), false, 'should fail if empty');
   assert.equal( validate('123'), true, 'should pass if valid');
   assert.equal( validate('12e'), false, 'should fail with non-digits');
@@ -31,9 +31,9 @@ test('validateCVC without card type', function(assert) {
 
 test('validateCVC with card type', function(assert) {
   var validate = validations.validateCVC;
-  
-  assert.equal( validate('123', 'amex'), true, 'should pass if amex with 3 digits');
-  assert.equal( validate('123', 'visa'), true, 'should validate a three digit number with card type other than amex');
+
+  assert.equal( validate('123', 'amex'), false, 'should not validate a three digit number with card type amex');
+  assert.equal( validate('123', 'visa'), true, 'should validate a three digit number with a card type other than amex');
   assert.equal( validate('1234', 'visa'), false, 'should not validate a four digit number with a card type other than amex');
   assert.equal( validate('1234', 'amex'), true, 'should validate a four digit number with card type amex');
 });


### PR DESCRIPTION
We've found that the amex cvv code on the front is only ever 4 digits. Are you dual purposing with the 3 digit code on the back that is a different security code?