### PR TITLE
Update input types to match Shopify

### DIFF
--- a/addon/components/input-credit-card-cvc.js
+++ b/addon/components/input-credit-card-cvc.js
@@ -6,9 +6,10 @@ import isWhitelistKeypress from 'ember-credit-cards/utils/is-whitelist-keypress'
 
 export default TextField.extend({
   classNames: ['input-credit-card-cvc'],
-  autocomplete: 'off',
+  autocomplete: 'cc-csc',
   placeholder: '•••',
   label: 'Expiration',
+  type: 'tel',
 
   keyPress: function(e) {
     var digit = String.fromCharCode(e.which);

--- a/addon/components/input-credit-card-expiration.js
+++ b/addon/components/input-credit-card-expiration.js
@@ -43,6 +43,8 @@ export default TextField.extend({
   year: null,
   placeholder: '•• / ••',
   autocomplete: 'cc-exp',
+  type: 'tel',
+  required: true,
 
   keyPress: function(e) {
     var digit = String.fromCharCode(e.which);

--- a/addon/components/input-credit-card-number.js
+++ b/addon/components/input-credit-card-number.js
@@ -25,6 +25,7 @@ export default TextField.extend({
   placeholder: '•••• •••• •••• ••••',
   autocomplete: 'cc-number',
   type: 'tel',
+  required: true,
 
   keyPress: function(e) {
     if (!isDigitKeypress(e)) {

--- a/addon/components/input-credit-card-zipcode.js
+++ b/addon/components/input-credit-card-zipcode.js
@@ -7,6 +7,8 @@ import isDigitKeypress from 'ember-credit-cards/utils/is-digit-keypress';
 export default TextField.extend({
   type: 'tel',
   classNames: ['input-credit-card-zipcode'],
+  autocomplete: 'none',
+  autocorrect: 'off',
 
   keyPress: function(e) {
     var digit = String.fromCharCode(e.which);


### PR DESCRIPTION
Thanks for maintaining this add-on. We use it and did a little research to match the patterns of Shopify and Stripe. Below are the results and this PR matches Shopify except for the ZipCode type that I left as is (type="tel"). They seem like reasonable defaults for this library. 

## Shopify

```html
<input
  aria-describedby="error-for-number tooltip-for-number"
  autocomplete="cc-number"
  placeholder="Card number"
  required=""
  type="tel"
/>
<input
  aria-describedby="error-for-expiry tooltip-for-expiry"
  autocomplete="cc-exp"
  placeholder="Expiration date (MM / YY)"
  required=""
  type="tel"
/>
<input
  aria-describedby="error-for-verification_value tooltip-for-verification_value"
  autocomplete="cc-csc"
  placeholder="Security code"
  type="tel"
/>
<input
  aria-required="true"
  autocomplete="none"
  autocorrect="off"
  placeholder="ZIP code"
  size="30"
  type="text"
/>
```

## Stripe Checkout
```html
<input
  aria-invalid="false"
  aria-label="Card number"
  autocomplete="cc-number"
  autocorrect="off"
  inputmode="numeric"
  placeholder="1234 1234 1234 1234"
  spellcheck="false"
  type="text"
/>
<input
  aria-invalid="false"
  aria-label="Expiration"
  autocomplete="cc-exp"
  autocorrect="off"
  inputmode="numeric"
  placeholder="MM / YY"
  spellcheck="false"
  type="text"
/>
<input
  aria-invalid="false"
  aria-label="CVC"
  autocomplete="cc-csc"
  autocorrect="off"
  inputmode="numeric"
  placeholder="CVC"
  spellcheck="false"
  type="text"
/>
<input
  aria-invalid="false"
  aria-label="ZIP"
  autocomplete="billing postal-code"
  autocorrect="off"
  inputmode="numeric"
  placeholder="ZIP"
  spellcheck="false"
  type="text"
/>
```

## Stripe Elements

```html
<input
  aria-invalid="false"
  aria-label="Credit or debit card number"
  autocomplete="cc-number"
  autocorrect="off"
  inputmode="numeric"
  placeholder="Card number"
  spellcheck="false"
  type="text"
/>
<input
  aria-invalid="false"
  aria-label="Credit or debit card expiration date"
  autocomplete="cc-exp"
  autocorrect="off"
  inputmode="numeric"
  placeholder="MM / YY"
  spellcheck="false"
  type="text"
/>
<input
  aria-invalid="false"
  aria-label="Credit or debit card CVC/CVV"
  autocomplete="cc-csc"
  autocorrect="off"
  inputmode="numeric"
  placeholder="CVC"
  spellcheck="false"
  type="text"
/>
<input
  autocomplete="postal-code"
  placeholder="94107"
  required=""
  type="text"
/>
```